### PR TITLE
Bsweger/update modeloutputhandler instantiation

### DIFF
--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -1,10 +1,11 @@
 import logging
+import os
 import re
 from urllib.parse import quote
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-from cloudpathlib import AnyPath
+from cloudpathlib import AnyPath, S3Path
 from pyarrow import csv, fs
 
 # Log to stdout
@@ -17,30 +18,58 @@ logger.setLevel(logging.INFO)
 
 
 class ModelOutputHandler:
-    def __init__(self, input_uri: str, output_uri: str):
-        input_filesystem = fs.FileSystem.from_uri(self.sanitize_uri(input_uri))
+    """
+    A class used to transform a Hubverse model-output file into a standardized format.
+
+    Attributes
+    ----------
+    file_name : str
+        name of the incoming model-output file to be transformed
+    file_type : str
+        type of file to be transformed (.parquet or .csv currently supported)
+    round_id : str
+        name of the round_id associated with the model-output file
+    model_id : int
+        name of the model_id associated with the model-output file
+    """
+
+    def __init__(self, hub_path: os.PathLike, mo_path: os.PathLike, output_path: os.PathLike):
+        """
+        Parameters
+        ----------
+        hub_path : os.PathLike
+            pathlike object that represents a hub's high-level storage location (e.g., S3 bucket name)
+        mo_path : os.PathLike
+            pathlike object that represents the location of a single model-output file, not including the hub_path
+            (e.g., S3 key)
+        output_path : os.PathLike
+            pathlike object that represents where the transformed version of the model-output file will be saved
+        """
+        input_path = hub_path / mo_path  # type: ignore
+        sanitized_input_uri = self.sanitize_uri(input_path)
+        input_filesystem = fs.FileSystem.from_uri(sanitized_input_uri)
         self.fs_input = input_filesystem[0]
         self.input_file = input_filesystem[1]
 
-        output_filesystem = fs.FileSystem.from_uri(self.sanitize_uri(output_uri))
+        output_filesystem = fs.FileSystem.from_uri(self.sanitize_uri(output_path))
         self.fs_output = output_filesystem[0]
         self.output_path = output_filesystem[1]
 
-        # get file name and type from input file
-        path = AnyPath(self.input_file)
-        self.file_name = path.stem
-        self.file_type = path.suffix
+        # get file name and type from input file (use the sanitized version)
+        file_path = AnyPath(self.input_file)
+        self.file_name = file_path.stem  # file name without extension
+        self.file_type = file_path.suffix
 
         # handle case when the function is triggered without a file
         # (e.g., if someone manually creates a folder in an S3 bucket)
-        if not path.suffix:
+        if not input_path.suffix:
             msg = "Input file has no extension"
-            self.raise_invalid_file_warning(str(path), msg)
+            self.raise_invalid_file_warning(str(input_path), msg)
 
         # TODO: Add other input file types as needed
         if self.file_type not in [".csv", ".parquet"]:
             msg = f"Input file type {self.file_type} is not supported"
-            self.raise_invalid_file_warning(str(path), msg)
+            self.raise_invalid_file_warning(str(input_path), msg)
 
         # Parse model-output file name into individual parts
         # (round_id, model_id)
@@ -62,17 +91,17 @@ class ModelOutputHandler:
         # data (i.e., as submitted my modelers). This check ensures that the file being
         # transformed has originated from wherever a hub keeps these "raw" (un-altered)
         # model-outputs.
-        path = AnyPath(s3_key)
-        if path.parts[0] != origin_prefix:
+        s3_mo_path = AnyPath(s3_key)
+        if s3_mo_path.parts[0] != origin_prefix:
             raise ValueError(f"Model output path {s3_key} does not begin with {origin_prefix}.")
 
-        s3_input_uri = f"s3://{bucket_name}/{s3_key}"
+        s3_bucket_path = S3Path(f"s3://{bucket_name}")
 
         # Destination path = origin path w/o the origin prefix
-        destination_path = str(path.relative_to(origin_prefix).parent)
-        s3_output_uri = f"s3://{bucket_name}/{destination_path}"
+        destination_path = str(s3_mo_path.relative_to(origin_prefix).parent)
+        s3_output_path = S3Path(f"s3://{bucket_name}/{destination_path}")
 
-        return cls(s3_input_uri, s3_output_uri)
+        return cls(s3_bucket_path, s3_mo_path, s3_output_path)  # type: ignore
 
     def raise_invalid_file_warning(self, path: str, msg: str) -> None:
         """Raise a warning if the class was instantiated with an invalid file."""
@@ -85,18 +114,15 @@ class ModelOutputHandler:
         )
         raise UserWarning(msg)
 
-    def sanitize_uri(self, uri: str, safe=":/") -> str:
+    def sanitize_uri(self, path: os.PathLike, safe=":/") -> str:
         """Sanitize URIs for use with pyarrow's filesystem."""
-
-        uri_path = AnyPath(uri)
 
         # remove spaces at the end of a filename (e.g., my-model-output .csv) and
         # also at the beginning and end of the path string
-        clean_path = AnyPath(str(uri_path).replace(uri_path.stem, uri_path.stem.strip()))
+        clean_path = AnyPath(str(path).replace(path.stem, path.stem.strip()))  # type: ignore
         clean_string = str(clean_path).strip()
 
-        # encode the cleaned path (for example, any remaining spaces) so we can
-        # safely use it as a URI
+        # encode the cleaned path (for example, any remaining spaces) so we can safely use it
         clean_uri = quote(str(clean_string), safe=safe)
 
         return clean_uri

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -26,7 +26,7 @@ class ModelOutputHandler:
     file_name : str
         name of the incoming model-output file to be transformed
     file_type : str
-        type of file to be transformed (.parquet or .csv currently supported)
+        type of file to be transformed (.parquet, .pqt, .csv currently supported)
     round_id : str
         name of the round_id associated with the model-output file
     model_id : int
@@ -67,7 +67,7 @@ class ModelOutputHandler:
             self.raise_invalid_file_warning(str(input_path), msg)
 
         # TODO: Add other input file types as needed
-        if self.file_type not in [".csv", ".parquet"]:
+        if self.file_type not in [".csv", ".parquet", ".pqt"]:
             msg = f"Input file type {self.file_type} is not supported"
             self.raise_invalid_file_warning(str(input_path), msg)
 

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -19,18 +19,19 @@ logger.setLevel(logging.INFO)
 
 class ModelOutputHandler:
     """
-    A class used to transform a Hubverse model-output file into a standardized format.
+    Transforms a Hubverse model-output file to a standard format.
 
     Attributes
     ----------
     file_name : str
-        name of the incoming model-output file to be transformed
+        Name of the incoming model-output file to be transformed.
     file_type : str
-        type of file to be transformed (.parquet, .pqt, .csv currently supported)
+        Type of file to be transformed
+        (.parquet, .pqt, .csv currently supported).
     round_id : str
-        name of the round_id associated with the model-output file
+        Name of the round_id associated with the model-output file.
     model_id : int
-        name of the model_id associated with the model-output file
+        Name of the model_id associated with the model-output file.
     """
 
     def __init__(self, hub_path: os.PathLike, mo_path: os.PathLike, output_path: os.PathLike):
@@ -38,13 +39,15 @@ class ModelOutputHandler:
         Parameters
         ----------
         hub_path : os.PathLike
-            pathlike object that represents a hub's high-level storage location (e.g., S3 bucket name)
+            The location of a Hubverse hub
+            (e.g., S3 bucket name, local filepath).
         mo_path : os.PathLike
-            pathlike object that represents the location of a single model-output file, not including the hub_path
-            (e.g., S3 key)
+            The location of a single model-output file, excluding
+            the hub_path (e.g., S3 key)
         output_path : os.PathLike
-            pathlike object that represents where the transformed version of the model-output file will be saved
+            Where the transformed model-output file will be saved.
         """
+
         input_path = hub_path / mo_path  # type: ignore
         sanitized_input_uri = self.sanitize_uri(input_path)
         input_filesystem = fs.FileSystem.from_uri(sanitized_input_uri)
@@ -85,7 +88,41 @@ class ModelOutputHandler:
 
     @classmethod
     def from_s3(cls, bucket_name: str, s3_key: str, origin_prefix: str = "raw") -> "ModelOutputHandler":
-        """Instantiate ModelOutputHandler for file on AWS S3."""
+        """
+        Factory method to create ModelOutputHandler for S3-based files.
+
+        Use this method to instantiate a ModelOutputHandler object for
+        model-output files store in an S3 bucket (for example, when
+        transformations are invoked via an AWS lambda function).
+
+        Parameters
+        ----------
+        bucket_name : str
+            The S3 bucket that contains the model-output file.
+        s3_key : str
+            The S3 object key of the model-output file.
+        origin_prefix : str, default="raw"
+            The S3 prefix used to store a hub's original,
+            pre-transformed data. Must be the first part of the s3_key.
+
+        Returns
+        -------
+        ModelOutputHandler
+            A new instance of ModelOutputHandler.
+
+        Raises
+        ------
+        ValueError
+            If the s3_key does not begin with the origin_prefix.
+
+        Examples
+        --------
+        >>> mo_handler = ModelOutputHandler.from_s3(
+            "my-bucket",
+            "original_files/2022-01-01_model_output.csv",
+            "original_files"
+            )
+        """
 
         # ModelOutputHandler is designed to operate on original versions of model-output
         # data (i.e., as submitted my modelers). This check ensures that the file being

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,7 +48,7 @@ def model_output_table() -> pa.Table:
 def model_output_data() -> list[dict[str, Any]]:
     """
     Fixture that returns a list of model-output data representing multiple output types.
-    This fixture is used as input for other fixtures that generate temporary .csv and .parquest files for testing.
+    This fixture is used as input for other fixtures that generate temporary .csv and .parquet files for testing.
     """
 
     model_output_fieldnames = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,112 @@
+import csv
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from pyarrow import csv as pyarrow_csv
+from pyarrow import fs
+from pyarrow import parquet as pq
+
+
+@pytest.fixture()
+def s3_bucket_name() -> str:  # type: ignore
+    """
+    PyArrow will not create FileSystem objects for S3 buckets that don't exist. The test suite isn't writing anything to S3,
+    so all we need is the name of an actual S3 bucket to pass to ModelOutputHandler. We could handle this via mocks, but those
+    attempts made the test suite highly unreadable, and setting up LocalStack or another AWS testing mechanism is a big hammer
+    for this purpose, so here's a fixture that will return a bucket name usable by the test suite.
+
+    Ultimately, this difficulty probably warrants a closer look at the code structure, because it shouldn't be this hard to test!
+    """
+
+    bucket_list = ["hubverse-assets", "test-bucket", "bucket123"]
+    for bucket in bucket_list:
+        try:
+            fs.FileSystem.from_uri(f"s3://{bucket}")
+            return bucket
+        except OSError:
+            continue
+        else:
+            raise ValueError("No valid S3 bucket found for testing ModelOutputHandler")
+
+
+@pytest.fixture()
+def model_output_table() -> pa.Table:
+    """
+    Simple model-output representation to test functions with a PyArrow table input.
+    """
+    return pa.table(
+        {
+            "location": ["earth", "vulcan", "seti alpha"],
+            "value": [11.11, 22.22, 33.33],
+        }
+    )
+
+
+@pytest.fixture()
+def model_output_data() -> list[dict[str, Any]]:
+    """
+    Fixture that returns a list of model-output data representing multiple output types.
+    This fixture is used as input for other fixtures that generate temporary .csv and .parquest files for testing.
+    """
+
+    model_output_fieldnames = [
+        "reference_date",
+        "location",
+        "horizon",
+        "target",
+        "output_type",
+        "output_type_id",
+        "value",
+    ]
+    model_output_list = [
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.5, 62],
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.75, 50.1],
+        ["2420-01-01", "03", 3, "hospitalizations", "mean", None, 33],
+        ["1999-12-31", "US", "last month", "hospitalizations", "pmf", "large_increase", 2.597827508665773e-9],
+    ]
+
+    model_output_dict_list = [
+        {field: value for field, value in zip(model_output_fieldnames, row)} for row in model_output_list
+    ]
+
+    return model_output_dict_list
+
+
+@pytest.fixture()
+def test_csv_file(tmpdir, model_output_data) -> str:
+    """
+    Write a temporary csv file and return the URI for use in tests.
+    """
+    test_file_dir = Path(tmpdir.mkdir("raw_csv"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.csv"
+    test_file_path = str(test_file_dir.joinpath(test_file_name))
+
+    fieldnames = model_output_data[0].keys()
+
+    with open(test_file_path, "w", newline="") as test_csv_file:
+        writer = csv.DictWriter(test_csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in model_output_data:
+            writer.writerow(row)
+
+    return str(test_file_path)
+
+
+@pytest.fixture()
+def test_parquet_file(tmpdir, test_csv_file) -> str:
+    """
+    Write a temporary parquet file and return the URI for use in tests.
+    """
+    test_file_dir = Path(tmpdir.mkdir("raw_parquet"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.parquet"
+    test_file_path = str(test_file_dir.joinpath(test_file_name))
+    local = fs.LocalFileSystem()
+
+    # read our test csv so we can write it back out as a parquet file
+    model_output_table = pyarrow_csv.read_csv(test_csv_file)
+    with local.open_output_stream(test_file_path) as test_parquet_file:
+        pq.write_table(model_output_table, test_parquet_file)
+
+    return str(test_file_path)

--- a/test/integration/test_model_output_integration.py
+++ b/test/integration/test_model_output_integration.py
@@ -17,9 +17,9 @@ def test_file_path() -> pathlib.Path:
 
 def test_missing_model_output_id_numeric(tmpdir, test_file_path):
     """Test behavior of model_output_id columns when there are a mix of numeric and missing output_type_ids."""
-    output_dir = str(tmpdir.mkdir("model-output"))
-    file_path = str(test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_numeric.csv"))
-    mo = ModelOutputHandler(file_path, output_dir)
+    output_path = pathlib.Path(tmpdir.mkdir("model-output"))
+    mo_path = test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_numeric.csv")
+    mo = ModelOutputHandler(pathlib.Path(tmpdir), mo_path, output_path)
     output_uri = mo.transform_model_output()
 
     # read the output parquet file
@@ -33,9 +33,9 @@ def test_missing_model_output_id_numeric(tmpdir, test_file_path):
 
 def test_missing_model_output_id_mixture(tmpdir, test_file_path):
     """Test behavior of model_output_id columns when there are a mix of numeric, string, and missing output_type_ids."""
-    output_dir = str(tmpdir.mkdir("model-output"))
-    file_path = str(test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_mixed.csv"))
-    mo = ModelOutputHandler(file_path, output_dir)
+    output_path = pathlib.Path(tmpdir.mkdir("model-output"))
+    mo_path = test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_mixed.csv")
+    mo = ModelOutputHandler(pathlib.Path(tmpdir), mo_path, output_path)
     output_uri = mo.transform_model_output()
 
     # read the output parquet file

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -1,102 +1,19 @@
-import csv
 from pathlib import Path
-from typing import Any
 
 import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
+from cloudpathlib import AnyPath
 from hubverse_transform.model_output import ModelOutputHandler
-from pyarrow import csv as pyarrow_csv
-from pyarrow import fs
 
-# note: the mocker fixture used throughout is provided by pytest-mock
-
-
-@pytest.fixture()
-def model_output_table() -> pa.Table:
-    """
-    Simple model-output representation to test functions with a PyArrow table input.
-    """
-    return pa.table(
-        {
-            "location": ["earth", "vulcan", "seti alpha"],
-            "value": [11.11, 22.22, 33.33],
-        }
-    )
-
-
-@pytest.fixture()
-def model_output_data() -> list[dict[str, Any]]:
-    """
-    Fixture that returns a list of model-output data representing multiple output types.
-    This fixture is used as input for other fixtures that generate temporary .csv and .parquest files for testing.
-    """
-
-    model_output_fieldnames = [
-        "reference_date",
-        "location",
-        "horizon",
-        "target",
-        "output_type",
-        "output_type_id",
-        "value",
-    ]
-    model_output_list = [
-        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.5, 62],
-        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.75, 50.1],
-        ["2420-01-01", "03", 3, "hospitalizations", "mean", None, 33],
-        ["1999-12-31", "US", "last month", "hospitalizations", "pmf", "large_increase", 2.597827508665773e-9],
-    ]
-
-    model_output_dict_list = [
-        {field: value for field, value in zip(model_output_fieldnames, row)} for row in model_output_list
-    ]
-
-    return model_output_dict_list
-
-
-@pytest.fixture()
-def test_csv_file(tmpdir, model_output_data) -> str:
-    """
-    Write a temporary csv file and return the URI for use in tests.
-    """
-    test_file_dir = Path(tmpdir.mkdir("raw_csv"))
-    test_file_name = "2420-01-01-janeswayaddition-voyager1.csv"
-    test_file_path = str(test_file_dir.joinpath(test_file_name))
-
-    fieldnames = model_output_data[0].keys()
-
-    with open(test_file_path, "w", newline="") as test_csv_file:
-        writer = csv.DictWriter(test_csv_file, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in model_output_data:
-            writer.writerow(row)
-
-    return str(test_file_path)
-
-
-@pytest.fixture()
-def test_parquet_file(tmpdir, test_csv_file) -> str:
-    """
-    Write a temporary parquet file and return the URI for use in tests.
-    """
-    test_file_dir = Path(tmpdir.mkdir("raw_parquet"))
-    test_file_name = "2420-01-01-janeswayaddition-voyager1.parquet"
-    test_file_path = str(test_file_dir.joinpath(test_file_name))
-    local = fs.LocalFileSystem()
-
-    # read our test csv so we can write it back out as a parquet file
-    model_output_table = pyarrow_csv.read_csv(test_csv_file)
-    with local.open_output_stream(test_file_path) as test_parquet_file:
-        pq.write_table(model_output_table, test_parquet_file)
-
-    return str(test_file_path)
+# the mocker fixture used throughout is provided by pytest-mock
+# see conftest.py for definition of other fixtures (e.g., s3_bucket_name)
 
 
 def test_new_instance():
-    input_uri = "mock:bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv"
-    output_uri = "mock:bucket123/prefix1/prefix2"
-    mo = ModelOutputHandler(input_uri, output_uri)
+    hub_path = AnyPath("mock:bucket123")
+    mo_path = AnyPath("raw/prefix1/prefix2/2420-01-01-team_one-model.csv")
+    output_path = AnyPath("mock:bucket123/prefix1/prefix2")
+    mo = ModelOutputHandler(hub_path, mo_path, output_path)
     assert mo.input_file == "bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv"
     assert mo.output_path == "bucket123/prefix1/prefix2"
     assert mo.file_name == "2420-01-01-team_one-model"
@@ -106,81 +23,68 @@ def test_new_instance():
 
 
 @pytest.mark.parametrize(
-    "original_uri, expected_sanitized_uri",
+    "mo_path_str, expected_round_id, expected_model_id",
     [
-        ("s3://hub-bucket/raw/round name/model name.parquet", "s3://hub-bucket/raw/round%20name/model%20name.parquet"),
-        ("mock:hub-bucket/raw/round name/model name.parquet", "mock:hub-bucket/raw/round%20name/model%20name.parquet"),
-        ("/tmp/bucket 1/a local file.csv", "/tmp/bucket%201/a%20local%20file.csv"),
+        ("raw/prefix/2420-01-01-team-model.csv", "2420-01-01", "team-model"),
+        ("raw/prefix/2420-01-01-----team-model.parquet", "2420-01-01", "team-model"),
+        ("raw/prefix/2420-01-01____teammodelallonestring.csv", "2420-01-01", "teammodelallonestring"),
+        ("raw/prefix/2420-01-01____look-at-all-the-hyphens-.csv", "2420-01-01", "look-at-all-the-hyphens-"),
     ],
 )
-def test_sanitize_uri(original_uri, expected_sanitized_uri):
-    # instantiate a ModelOutputHandler object with uris we don't care about (as a way to
-    # test the sanitize_uri method against various types of URIs supported by the pyarrow filesystem
-    mo = ModelOutputHandler("mock:/input-uri/2024-01-01 file.parquet", "mock:/output-uri")
+def test_parse_file(tmpdir, s3_bucket_name, mo_path_str, expected_round_id, expected_model_id):
+    """Test getting round_id and model_id from file name."""
+    mo_path = AnyPath(mo_path_str)
+    output_path = AnyPath(tmpdir)
 
-    assert mo.sanitize_uri(original_uri) == expected_sanitized_uri
+    # test parsing with S3 path and local path
+    hub_path_list = [AnyPath(f"s3://{s3_bucket_name}"), AnyPath(tmpdir)]
+    for hub_path in hub_path_list:
+        mo = ModelOutputHandler(hub_path, mo_path, output_path)
+        assert mo.round_id == expected_round_id
+        assert mo.model_id == expected_model_id
 
 
 @pytest.mark.parametrize(
-    "file_uri, expected_round_id, expected_model_id",
-    [
-        ("mock:raw/prefix/2420-01-01-team-model.csv", "2420-01-01", "team-model"),
-        ("mock:raw/prefix/2420-01-01-----team-model.parquet", "2420-01-01", "team-model"),
-        ("mock:raw/prefix/2420-01-01____teammodelallonestring.csv", "2420-01-01", "teammodelallonestring"),
-        ("mock:raw/prefix/2420-01-01____look-at-all-the-hyphens-.csv", "2420-01-01", "look-at-all-the-hyphens-"),
-    ],
-)
-def test_parse_file(file_uri, expected_round_id, expected_model_id):
-    mo = ModelOutputHandler(file_uri, "mock:/output-uri")
-    assert mo.round_id == expected_round_id
-    assert mo.model_id == expected_model_id
-
-
-@pytest.mark.parametrize(
-    "input_uri, output_uri, expected_input_file, expected_output_path, expected_file_name, expected_model_id",
+    "mo_path_str, expected_input_file, expected_output_path, expected_file_name, expected_model_id",
     [
         (
-            "mock:bucket123/raw/prefix1/prefix 2/2420-01-01-team-model name with spaces.csv",
-            "mock:bucket123/prefix1/prefix 2",
-            "bucket123/raw/prefix1/prefix 2/2420-01-01-team-model name with spaces.csv",
-            "bucket123/prefix1/prefix 2",
+            "raw/prefix1/prefix 2/2420-01-01-team-model name with spaces.csv",
+            "raw/prefix1/prefix 2/2420-01-01-team-model name with spaces.csv",
+            "prefix1/prefix 2",
             "2420-01-01-team-model name with spaces",
             "team-model name with spaces",
         ),
         (
-            "mock:bucket1.2.3/raw/prefix1/prefix 2/2420-01-01-team-model.name.csv",
-            "mock:bucket123/prefix1/~prefix 2",
-            "bucket1.2.3/raw/prefix1/prefix 2/2420-01-01-team-model.name.csv",
-            "bucket123/prefix1/~prefix 2",
+            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.csv",
+            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.csv",
+            "prefix1/~prefix 2",
             "2420-01-01-team-model.name",
             "team-model.name",
         ),
         (
-            "mock:raw/prefix 1/prefix2/2420-01-01-spáces at end .csv",
-            "mock:prefix 1/prefix2",
-            "raw/prefix 1/prefix2/2420-01-01-spáces at end.csv",
-            "prefix 1/prefix2",
+            "raw/raw/prefix 1/prefix2/2420-01-01-spáces at end .csv",
+            "raw/raw/prefix 1/prefix2/2420-01-01-spáces at end.csv",
+            "raw/prefix 1/prefix2",
             "2420-01-01-spáces at end",
             "spáces at end",
         ),
         (
-            "mock:a space/prefix 1/prefix2/2420-01-01 look ma no hyphens.csv",
-            "mock:prefix 1/prefix 🐍",
-            "a space/prefix 1/prefix2/2420-01-01 look ma no hyphens.csv",
+            "raw/prefix 1/prefix 🐍/2420-01-01 look ma no hyphens.csv",
+            "raw/prefix 1/prefix 🐍/2420-01-01 look ma no hyphens.csv",
             "prefix 1/prefix 🐍",
             "2420-01-01 look ma no hyphens",
             "look ma no hyphens",
         ),
     ],
 )
-def test_new_instance_special_characters(
-    input_uri, output_uri, expected_input_file, expected_output_path, expected_file_name, expected_model_id
+def test_from_s3_special_characters(
+    s3_bucket_name, mo_path_str, expected_input_file, expected_output_path, expected_file_name, expected_model_id
 ):
+    """Test special characters when instaniating ModelOutputHandler via from_s3"""
     # ensure spaces and other characters in directory, filename, s3 key, etc. are handled correctly
-
-    mo = ModelOutputHandler(input_uri, output_uri)
-    assert mo.input_file == expected_input_file
-    assert mo.output_path == expected_output_path
+    mo = ModelOutputHandler.from_s3(s3_bucket_name, mo_path_str)
+    assert mo.input_file == f"{s3_bucket_name}/{expected_input_file}"
+    assert mo.output_path == f"{s3_bucket_name}/{expected_output_path}"
     assert mo.file_name == expected_file_name
     assert mo.model_id == expected_model_id
 
@@ -190,63 +94,72 @@ def test_new_instance_special_characters(
     [
         (
             "raw/prefix1/prefix2/2420-01-01-team-model.csv",
-            "s3://bucket123/raw/prefix1/prefix2/2420-01-01-team-model.csv",
-            "s3://bucket123/prefix1/prefix2",
+            "s3://hubverse-test/raw/prefix1/prefix2/2420-01-01-team-model.csv",
+            "s3://hubverse-test/prefix1/prefix2",
         ),
         (
             "raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet",
-            "s3://bucket123/raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet",
-            "s3://bucket123/model-output/prefix1/prefix2",
+            "s3://hubverse-test/raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet",
+            "s3://hubverse-test/model-output/prefix1/prefix2",
         ),
         (
             "raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv",
-            "s3://bucket123/raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv",
-            "s3://bucket123/prefix1/prefix2/prefix3/prefix4",
+            "s3://hubverse-test/raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv",
+            "s3://hubverse-test/prefix1/prefix2/prefix3/prefix4",
         ),
-        ("raw/2420-01-01-team-model.csv", "s3://bucket123/raw/2420-01-01-team-model.csv", "s3://bucket123/."),
+        ("raw/2420-01-01-team-model.csv", "s3://hubverse-test/raw/2420-01-01-team-model.csv", "s3://hubverse-test/."),
     ],
 )
 def test_from_s3(mocker, s3_key, expected_input_uri, expected_output_uri):
+    s3_expected_input_path = AnyPath(expected_input_uri)
+    hub_path = s3_expected_input_path.parents[-1]
+    mo_path = AnyPath(s3_expected_input_path.key)
+
     mocker.patch("hubverse_transform.model_output.ModelOutputHandler.__init__", return_value=None)
-    mo = ModelOutputHandler.from_s3("bucket123", s3_key)
-    mo.__init__.assert_called_once_with(expected_input_uri, expected_output_uri)
+    mo = ModelOutputHandler.from_s3("hubverse-test", s3_key)
+    mo.__init__.assert_called_once_with(hub_path, mo_path, AnyPath(expected_output_uri))
 
 
 def test_from_s3_alternate_origin_prefix(mocker):
     mocker.patch("hubverse_transform.model_output.ModelOutputHandler.__init__", return_value=None)
+
     mo = ModelOutputHandler.from_s3(
-        "bucket123",
+        "hubverse-test",
         "different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet",
         origin_prefix="different-raw-prefix",
     )
     mo.__init__.assert_called_once_with(
-        "s3://bucket123/different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet",
-        "s3://bucket123/prefix1/prefix2",
+        AnyPath("s3://hubverse-test"),
+        AnyPath("different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet"),
+        AnyPath("s3://hubverse-test/prefix1/prefix2"),
     )
 
 
 def test_from_s3_missing_prefix():
     with pytest.raises(ValueError):
-        ModelOutputHandler.from_s3("test-bucket", "prefix1/2420-01-01-team_name-model.csv")
+        ModelOutputHandler.from_s3("hubverse-test", "prefix1/2420-01-01-team_name-model.csv")
 
 
 @pytest.mark.parametrize(
     "file_uri, expected_error",
     [
-        ("mock:raw/prefix1/prefix2/2420-01-01.csv", ValueError),
-        ("mock:raw/prefix1/prefix2/round_id-team-model.csv", ValueError),
-        ("mock:raw/prefix1/prefix2/01-02-2440-team-model-name.csv", ValueError),
+        ("raw/prefix1/prefix2/2420-01-01.csv", ValueError),
+        ("raw/prefix1/prefix2/round_id-team-model.csv", ValueError),
+        ("raw/prefix1/prefix2/01-02-2440-team-model-name.csv", ValueError),
     ],
 )
-def test_parse_s3_key_invalid_format(file_uri, expected_error):
+def test_parse_s3_key_invalid_format(tmpdir, file_uri, expected_error):
     # ensure ValueError is raised for invalid model-output file name format
     with pytest.raises(expected_error):
-        ModelOutputHandler(file_uri, "mock:fake-output-uri")
+        hub_path = AnyPath(tmpdir)
+        mo_path = AnyPath(file_uri)
+        ModelOutputHandler(hub_path, mo_path, hub_path)
 
 
-def test_add_columns(model_output_table):
-    file_uri = "mock:raw/prefix1/prefix2/2420-01-01-team-model.csv"
-    mo = ModelOutputHandler(file_uri, "mock:fake-output-uri")
+def test_add_columns(tmpdir, model_output_table):
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath("raw/prefix1/prefix2/2420-01-01-team-model.csv")
+    mo = ModelOutputHandler(hub_path, mo_path, hub_path)
 
     result = mo.add_columns(model_output_table)
 
@@ -255,9 +168,11 @@ def test_add_columns(model_output_table):
     assert set(["round_id", "model_id"]).issubset(result.column_names)
 
 
-def test_added_column_values(model_output_table):
-    file_uri = "mock:raw/prefix1/prefix2/2420-01-01-janewaysaddiction-voyager1.csv"
-    mo = ModelOutputHandler(file_uri, "mock:fake-output-uri")
+def test_added_column_values(tmpdir, model_output_table):
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath("raw/prefix1/prefix2/2420-01-01-janewaysaddiction-voyager1.csv")
+
+    mo = ModelOutputHandler(hub_path, mo_path, hub_path)
 
     result = mo.add_columns(model_output_table)
 
@@ -270,8 +185,10 @@ def test_added_column_values(model_output_table):
     result.column("model_id").unique()[0].as_py() == "janewaysaddiction-voyager1"
 
 
-def test_read_file_csv(test_csv_file, model_output_table):
-    mo = ModelOutputHandler(test_csv_file, "mock:fake-output-uri")
+def test_read_file_csv(tmpdir, test_csv_file, model_output_table):
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath(test_csv_file)
+    mo = ModelOutputHandler(hub_path, mo_path, hub_path)
     pyarrow_table = mo.read_file()
     assert len(pyarrow_table) == 4
 
@@ -282,8 +199,10 @@ def test_read_file_csv(test_csv_file, model_output_table):
     assert str(output_type_id_col[3]) == "large_increase"
 
 
-def test_read_file_parquet(test_parquet_file, model_output_table):
-    mo = ModelOutputHandler(test_parquet_file, "mock:fake-output-uri")
+def test_read_file_parquet(tmpdir, test_parquet_file, model_output_table):
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath(test_parquet_file)
+    mo = ModelOutputHandler(hub_path, mo_path, hub_path)
     pyarrow_table = mo.read_file()
     assert len(pyarrow_table) == 4
 
@@ -295,19 +214,24 @@ def test_read_file_parquet(test_parquet_file, model_output_table):
 
 
 def test_write_parquet(tmpdir, model_output_table):
-    output_dir = str(tmpdir.mkdir("model-output"))
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath("raw/prefix1/prefix2/2420-01-01-team-model.csv")
+    output_path = AnyPath(tmpdir.mkdir("model-output"))
 
-    mo = ModelOutputHandler("mock:raw/prefix1/prefix2/2420-01-01-team-model.csv", output_dir)
+    mo = ModelOutputHandler(hub_path, mo_path, output_path)
 
-    expected_output_file_path = str(Path(*[output_dir, f"{mo.file_name}.parquet"]))
+    expected_output_file_path = str(Path(*[output_path, f"{mo.file_name}.parquet"]))
     actual_output_file_path = mo.write_parquet(model_output_table)
 
     assert actual_output_file_path == expected_output_file_path
 
 
 def test_transform_model_output_path(test_csv_file, tmpdir):
-    output_dir = str(tmpdir.mkdir("model-output"))
-    mo = ModelOutputHandler(test_csv_file, output_dir)
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath(test_csv_file)
+    output_path = AnyPath(str(tmpdir.mkdir("model-output")))
+
+    mo = ModelOutputHandler(hub_path, mo_path, output_path)
     output_uri = mo.transform_model_output()
 
     input_path = Path(test_csv_file)
@@ -321,13 +245,16 @@ def test_transform_model_output_path(test_csv_file, tmpdir):
 @pytest.mark.parametrize(
     "file_uri",
     [
-        ("mock:raw/prefix1/prefix2/"),
-        ("mock:raw/prefix1/prefix2/round_id-team-model.txt"),
-        ("mock:photo.jpg"),
-        ("mock:raw/prefix1/prefix2/01-02-2440-team-model-name"),
+        ("raw/prefix1/prefix2/"),
+        ("raw/prefix1/prefix2/round_id-team-model.txt"),
+        ("photo.jpg"),
+        ("raw/prefix1/prefix2/01-02-2440-team-model-name"),
     ],
 )
-def test_invalid_file_warning(file_uri):
+def test_invalid_file_warning(tmpdir, file_uri):
     # ensure ValueError is raised for invalid model-output file name format
+
+    hub_path = AnyPath(tmpdir)
+    mo_path = AnyPath(file_uri)
     with pytest.raises(UserWarning):
-        ModelOutputHandler(file_uri, "mock:fake-output-uri")
+        ModelOutputHandler(hub_path, mo_path, hub_path)

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -55,8 +55,8 @@ def test_parse_file(tmpdir, s3_bucket_name, mo_path_str, expected_round_id, expe
             "team-model name with spaces",
         ),
         (
-            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.csv",
-            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.csv",
+            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.pqt",
+            "raw/prefix1/~prefix 2/2420-01-01-team-model.name.pqt",
             "prefix1/~prefix 2",
             "2420-01-01-team-model.name",
             "team-model.name",
@@ -125,12 +125,12 @@ def test_from_s3_alternate_origin_prefix(mocker):
 
     mo = ModelOutputHandler.from_s3(
         "hubverse-test",
-        "different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet",
+        "different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.snappy.parquet",
         origin_prefix="different-raw-prefix",
     )
     mo.__init__.assert_called_once_with(
         AnyPath("s3://hubverse-test"),
-        AnyPath("different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet"),
+        AnyPath("different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.snappy.parquet"),
         AnyPath("s3://hubverse-test/prefix1/prefix2"),
     )
 

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -80,7 +80,7 @@ def test_parse_file(tmpdir, s3_bucket_name, mo_path_str, expected_round_id, expe
 def test_from_s3_special_characters(
     s3_bucket_name, mo_path_str, expected_input_file, expected_output_path, expected_file_name, expected_model_id
 ):
-    """Test special characters when instaniating ModelOutputHandler via from_s3"""
+    """Test special characters when instantiating ModelOutputHandler via from_s3"""
     # ensure spaces and other characters in directory, filename, s3 key, etc. are handled correctly
     mo = ModelOutputHandler.from_s3(s3_bucket_name, mo_path_str)
     assert mo.input_file == f"{s3_bucket_name}/{expected_input_file}"


### PR DESCRIPTION
This PR is a re-factor that lays the groundwork for addressing this issue: https://github.com/hubverse-org/hubverse-transform/issues/14

To get a hub-specific schema, the hubverse transform will need to know that top-level location of the hub (so it can find `hub-config`. To make getting that information more straightforward, we'll now instantiate `ModelOutputHandler` with 3 parameters instead of 2 (splitting the high-level hub location from the remainder of the incoming model-output path).