### PR TITLE
First set of changes for HubConfig object

### DIFF
--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+from cloudpathlib import AnyPath
+
+
+class HubConfig:
+    """
+    Represents the configuration of a Hubverse hub.
+
+    Attributes
+    ----------
+    """
+
+    def __init__(
+        self,
+        hub_path: os.PathLike,
+        config_dir: str = "hub-config",
+        admin_file: str = "admin.json",
+        tasks_file: str = "tasks.json",
+    ):
+        """
+        Parameters
+        ----------
+        hub_path : os.PathLike
+            The location of a Hubverse hub
+            (e.g., S3 bucket name, local filepath).
+        config_dir : str, default="hub-config"
+            Directory containing the hub's configuration files
+        admin_file : str, default="admin.json"
+            Filename of the hub's admin configuration file.
+        tasks_file : str, default="tasks.json"
+            Filename of the hub's tasks configuration file.
+        """
+
+        self.hub_config_path = AnyPath(hub_path) / config_dir
+        self.admin = self._get_admin_config(admin_file)
+        self.tasks = self._get_tasks_config(tasks_file)
+        self.hub_name = self.admin.get("name", "unknown hub name")
+
+    def __repr__(self):
+        return f"HubConfig('{str(self.hub_config_path)}')"
+
+    def __str__(self):
+        return f"Hubverse config information for {self.hub_name}."
+
+    def _get_admin_config(self, admin_file: str):
+        """Read a Hubverse hub's admin configuration file."""
+        admin_path = self.hub_config_path / admin_file
+
+        if not admin_path.exists():
+            raise FileNotFoundError(f"Hub admin config not found at {str(admin_path)}")
+
+        with admin_path.open() as f:
+            return json.loads(f.read())
+
+    def _get_tasks_config(self, tasks_file: str):
+        """Read a Hubverse hub's tasks configuration file."""
+        tasks_path = self.hub_config_path / tasks_file
+
+        if not tasks_path.exists():
+            raise FileNotFoundError(f"Hub tasks config not found at {str(tasks_path)}")
+
+        with tasks_path.open() as f:
+            return json.loads(f.read())

--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="operator"
+
 import json
 import os
 

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="operator"
+
 import logging
 import os
 import re
@@ -48,7 +50,7 @@ class ModelOutputHandler:
             Where the transformed model-output file will be saved.
         """
 
-        input_path = hub_path / mo_path  # type: ignore
+        input_path = hub_path / mo_path
         sanitized_input_uri = self.sanitize_uri(input_path)
         input_filesystem = fs.FileSystem.from_uri(sanitized_input_uri)
         self.fs_input = input_filesystem[0]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,7 @@
-import csv
-from pathlib import Path
-from typing import Any
+"""Shared pytest fixtures."""
 
-import pyarrow as pa
 import pytest
-from pyarrow import csv as pyarrow_csv
 from pyarrow import fs
-from pyarrow import parquet as pq
 
 
 @pytest.fixture()
@@ -29,84 +24,3 @@ def s3_bucket_name() -> str:  # type: ignore
             continue
         else:
             raise ValueError("No valid S3 bucket found for testing ModelOutputHandler")
-
-
-@pytest.fixture()
-def model_output_table() -> pa.Table:
-    """
-    Simple model-output representation to test functions with a PyArrow table input.
-    """
-    return pa.table(
-        {
-            "location": ["earth", "vulcan", "seti alpha"],
-            "value": [11.11, 22.22, 33.33],
-        }
-    )
-
-
-@pytest.fixture()
-def model_output_data() -> list[dict[str, Any]]:
-    """
-    Fixture that returns a list of model-output data representing multiple output types.
-    This fixture is used as input for other fixtures that generate temporary .csv and .parquet files for testing.
-    """
-
-    model_output_fieldnames = [
-        "reference_date",
-        "location",
-        "horizon",
-        "target",
-        "output_type",
-        "output_type_id",
-        "value",
-    ]
-    model_output_list = [
-        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.5, 62],
-        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.75, 50.1],
-        ["2420-01-01", "03", 3, "hospitalizations", "mean", None, 33],
-        ["1999-12-31", "US", "last month", "hospitalizations", "pmf", "large_increase", 2.597827508665773e-9],
-    ]
-
-    model_output_dict_list = [
-        {field: value for field, value in zip(model_output_fieldnames, row)} for row in model_output_list
-    ]
-
-    return model_output_dict_list
-
-
-@pytest.fixture()
-def test_csv_file(tmpdir, model_output_data) -> str:
-    """
-    Write a temporary csv file and return the URI for use in tests.
-    """
-    test_file_dir = Path(tmpdir.mkdir("raw_csv"))
-    test_file_name = "2420-01-01-janeswayaddition-voyager1.csv"
-    test_file_path = str(test_file_dir.joinpath(test_file_name))
-
-    fieldnames = model_output_data[0].keys()
-
-    with open(test_file_path, "w", newline="") as test_csv_file:
-        writer = csv.DictWriter(test_csv_file, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in model_output_data:
-            writer.writerow(row)
-
-    return str(test_file_path)
-
-
-@pytest.fixture()
-def test_parquet_file(tmpdir, test_csv_file) -> str:
-    """
-    Write a temporary parquet file and return the URI for use in tests.
-    """
-    test_file_dir = Path(tmpdir.mkdir("raw_parquet"))
-    test_file_name = "2420-01-01-janeswayaddition-voyager1.parquet"
-    test_file_path = str(test_file_dir.joinpath(test_file_name))
-    local = fs.LocalFileSystem()
-
-    # read our test csv so we can write it back out as a parquet file
-    model_output_table = pyarrow_csv.read_csv(test_csv_file)
-    with local.open_output_stream(test_file_path) as test_parquet_file:
-        pq.write_table(model_output_table, test_parquet_file)
-
-    return str(test_file_path)

--- a/test/unit/test_hub_config.py
+++ b/test/unit/test_hub_config.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+from cloudpathlib import AnyPath
+from hubverse_transform.hub_config import HubConfig
+
+
+@pytest.fixture()
+def admin_config() -> dict:
+    """
+    Return a Hubverse admin.json config.
+    """
+    admin_config_dict = {
+        "schema_version": "https://link_to_admin_schema.json",
+        "name": "Borg Assimilation Forecast Hub",
+        "maintainer": "Starfleet",
+        "contact": {"name": "Katherine Janeway", "email": "janeway@starfleet.com"},
+        "repository_host": "GitHub",
+        "repository_url": "https://github.com/starfleet/borg-assimilation-forecast-hub",
+        "file_format": ["csv"],
+        "model_output_dir": "model-output",
+        "cloud": {
+            "enabled": True,
+            "host": {"name": "aws", "storage_service": "s3", "storage_location": "borg-assimilation-forecast"},
+        },
+    }
+
+    return admin_config_dict
+
+
+@pytest.fixture()
+def tasks_config() -> dict:
+    """
+    Return a Hubverse admin.json config.
+    """
+    task_config_dict = {
+        "schema_version": "https://link_to_tasks_schema.json",
+        "rounds": [
+            {
+                "round_id_from_variable": True,
+                "round_id": "reference_date",
+                "model_tasks": [
+                    {
+                        "task_ids": {
+                            "reference_date": {"required": None, "optional": ["2024-07-13", "2024-07-21"]},
+                            "target": {"required": ["borg growth rate change"]},
+                            "horizon": {"required": None, "optional": [-1, 0, 1, 2, 3]},
+                            "location": {"required": ["Earth", "Vulcan", "789"], "optional": ["Ryza", "123"]},
+                            "target_end_date": {"required": None, "optional": ["2024-07-20", "2024-07-27"]},
+                        },
+                        "output_type": {
+                            "pmf": {
+                                "output_type_id": {"required": ["decrease", "stable", "increase"]},
+                                "value": {"type": "double", "minimum": 0, "maximum": 1},
+                            }
+                        },
+                    },
+                    {
+                        "task_ids": {
+                            "reference_date": {"required": None, "optional": ["2024-07-13", "2024-07-21"]},
+                            "target": {"required": ["wk number assimilations"]},
+                            "horizon": {"required": ["one", "two", "three"]},
+                            "location": {"required": ["Earth", "Vulcan", "789"], "optional": ["Ryza", "123"]},
+                            "target_end_date": {"required": None, "optional": ["2024-07-20", "2024-07-27"]},
+                        },
+                        "output_type": {
+                            "quantile": {
+                                "output_type_id": {"required": [0.25, 0.5, 0.75], "optional": None},
+                                "value": {"type": "double", "minimum": 0},
+                            }
+                        },
+                    },
+                ],
+                "submissions_due": {"relative_to": "reference_date", "start": -6, "end": -3},
+            }
+        ],
+    }
+
+    return task_config_dict
+
+
+@pytest.fixture()
+def hubverse_hub(tmp_path, admin_config, tasks_config):
+    """
+    Return a Hubverse hub with sample config files.
+    """
+    hub_path = tmp_path / "hubverse-hub"
+    hub_path.mkdir()
+    config_dir = hub_path / "hub-config"
+    config_dir.mkdir()
+
+    # write admin config
+    admin_config_file = config_dir / "admin.json"
+    with open(admin_config_file, "w") as f:
+        json.dump(admin_config, f)
+
+    # write tasks config
+    task_config_file = config_dir / "tasks.json"
+    with open(task_config_file, "w") as f:
+        json.dump(tasks_config, f)
+
+    return hub_path
+
+
+def test_hub_config_new_instance(hubverse_hub, admin_config, tasks_config):
+    hub_path = AnyPath(hubverse_hub)
+    hc = HubConfig(hub_path)
+
+    assert hc.hub_config_path == hub_path / "hub-config"
+    assert hc.admin == admin_config
+    assert hc.tasks == tasks_config
+    assert hc.hub_name == "Borg Assimilation Forecast Hub"
+    assert hc.hub_name in hc.__str__()
+    assert str(hc.hub_config_path) in hc.__repr__()
+
+
+def test_hub_missing_admin_config(hubverse_hub):
+    hub_path = AnyPath(hubverse_hub)
+
+    with pytest.raises(FileNotFoundError):
+        hc = HubConfig(hub_path, "missing-config-dir")
+        print(hc)
+
+
+def test_hub_missing_tasks_config(hubverse_hub):
+    hub_path = AnyPath(hubverse_hub)
+
+    with pytest.raises(FileNotFoundError):
+        hc = HubConfig(hub_path, tasks_file="missing-tasks.json")
+        print(hc)

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -1,12 +1,100 @@
+"""Unit tests for the ModelOutputHandler class."""
+
+import csv
 from pathlib import Path
+from typing import Any
 
 import pyarrow as pa
 import pytest
 from cloudpathlib import AnyPath
 from hubverse_transform.model_output import ModelOutputHandler
+from pyarrow import csv as pyarrow_csv
+from pyarrow import fs
+from pyarrow import parquet as pq
 
 # the mocker fixture used throughout is provided by pytest-mock
 # see conftest.py for definition of other fixtures (e.g., s3_bucket_name)
+
+
+@pytest.fixture()
+def model_output_table() -> pa.Table:
+    """
+    Simple model-output representation to test functions with a PyArrow table input.
+    """
+    return pa.table(
+        {
+            "location": ["earth", "vulcan", "seti alpha"],
+            "value": [11.11, 22.22, 33.33],
+        }
+    )
+
+
+@pytest.fixture()
+def model_output_data() -> list[dict[str, Any]]:
+    """
+    Fixture that returns a list of model-output data representing multiple output types.
+    This fixture is used as input for other fixtures that generate temporary .csv and .parquet files for testing.
+    """
+
+    model_output_fieldnames = [
+        "reference_date",
+        "location",
+        "horizon",
+        "target",
+        "output_type",
+        "output_type_id",
+        "value",
+    ]
+    model_output_list = [
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.5, 62],
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.75, 50.1],
+        ["2420-01-01", "03", 3, "hospitalizations", "mean", None, 33],
+        ["1999-12-31", "US", "last month", "hospitalizations", "pmf", "large_increase", 2.597827508665773e-9],
+    ]
+
+    model_output_dict_list = [
+        {field: value for field, value in zip(model_output_fieldnames, row)} for row in model_output_list
+    ]
+
+    return model_output_dict_list
+
+
+@pytest.fixture()
+def test_csv_file(tmpdir, model_output_data) -> str:
+    """
+    Write a temporary csv file and return the URI for use in tests.
+    """
+    test_file_dir = Path(tmpdir.mkdir("raw_csv"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.csv"
+    test_file_path = str(test_file_dir.joinpath(test_file_name))
+
+    fieldnames = model_output_data[0].keys()
+
+    with open(test_file_path, "w", newline="") as test_csv_file:
+        writer = csv.DictWriter(test_csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in model_output_data:
+            writer.writerow(row)
+
+    return str(test_file_path)
+
+
+@pytest.fixture()
+def test_parquet_file(tmpdir, test_csv_file) -> str:
+    """
+    Write a temporary parquet file and return the URI for use in tests.
+    """
+    test_file_dir = Path(tmpdir.mkdir("raw_parquet"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.parquet"
+    test_file_path = str(test_file_dir.joinpath(test_file_name))
+    local = fs.LocalFileSystem()
+
+    # read our test csv so we can write it back out as a parquet file
+    model_output_table = pyarrow_csv.read_csv(test_csv_file)
+    with local.open_output_stream(test_file_path) as test_parquet_file:
+        pq.write_table(model_output_table, test_parquet_file)
+
+    return str(test_file_path)
 
 
 def test_new_instance():


### PR DESCRIPTION
This is the first in a series of PRs to [add a new feature to hubverse-transform: inferring a hub's schema and using it when reading individual model-output files](https://github.com/hubverse-org/hubverse-transform/issues/14).

This can be reviewed commit-by-commit. The substantive change is adding a new HubConfig object that will eventually be used by ModelOutputHandler when reading data. This first bit of functionality reads a hub's admin and tasks config files.