### PR TITLE
Bsweger/get task id values

### DIFF
--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -82,8 +82,8 @@ class HubConfig:
         model_tasks_dict: dict[str, set] = dict()
 
         for r in rounds:
-            for task in r.get("model_tasks", []):
-                task_values = self._get_task_id_values(task)
+            for task_set in r.get("model_tasks", []):
+                task_values = self._get_task_id_values(task_set)
                 for key, value in task_values.items():
                     model_tasks_dict[key] = model_tasks_dict.get(key, set()) | value
 
@@ -109,12 +109,12 @@ class HubConfig:
         with tasks_path.open() as f:
             return json.loads(f.read())
 
-    def _get_task_id_values(self, task: dict) -> dict[str, set]:
+    def _get_task_id_values(self, task_set: dict) -> dict[str, set]:
         """Return a dict of ids and values for a specific modeling task."""
         task_id_values = dict()
 
         # create a dictionary of all tasks ids and values for this task
-        task_ids = {task_id[0]: task_id[1] for task_id in task.get("task_ids", {}).items()}
+        task_ids = {task_id[0]: task_id[1] for task_id in task_set.get("task_ids", {}).items()}
 
         # flatten the dictionary values for each task_id (i.e., combine "required" and "optional" lists)
         for task_id in task_ids.items():

--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -50,7 +50,7 @@ class HubConfig:
 
     def get_task_id_values(self) -> dict[str, set]:
         """
-        Return a dict of hub task ids and values for a specific round.
+        Return a dict of hub task ids and required and optional values across all rounds.
 
         Returns
         -------

--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -1,7 +1,8 @@
-# mypy: disable-error-code="operator"
+# mypy: disable-error-code="operator, arg-type"
 
 import json
 import os
+from datetime import date
 
 from cloudpathlib import AnyPath
 
@@ -65,3 +66,16 @@ class HubConfig:
 
         with tasks_path.open() as f:
             return json.loads(f.read())
+
+    def _get_data_type(self, value: int | bool | str | date | float) -> type:
+        """Return the data type of a value."""
+        data_type = type(value)
+
+        if data_type == str:
+            try:
+                date.fromisoformat(value)
+                data_type = date
+            except ValueError:
+                pass
+
+        return data_type

--- a/src/hubverse_transform/hub_config.py
+++ b/src/hubverse_transform/hub_config.py
@@ -48,36 +48,19 @@ class HubConfig:
     def __str__(self):
         return f"Hubverse config information for {self.hub_name}."
 
-    def get_task_id_values(self, round_name: str = "all") -> dict[str, set]:
+    def get_task_id_values(self) -> dict[str, set]:
         """
         Return a dict of hub task ids and values for a specific round.
-
-        Parameters
-        ----------
-        round_name : str, default="all"
-            Which round's tasks to include. If "all", return tasks
-            and values for all rounds.
 
         Returns
         -------
         model_tasks : dict[str, list]
             A mapping of tasks ids to their possible values, as
             defined in a hub's tasks.json configuration file.
-
-        Raises
-        ------
-        ValueError
-            If the tasks configuration file doesn't contain the
-            specified round_name.
         """
 
         tasks = self.tasks
         rounds = tasks.get("rounds", [])
-        if round_name != "all":
-            rounds = [r for r in rounds if r.get("round_name") == round_name]
-
-        if len(rounds) == 0:
-            raise ValueError(f"Round {round_name} not found in tasks configuration")
 
         model_tasks_dict: dict[str, set] = dict()
 

--- a/test/unit/test_hub_config.py
+++ b/test/unit/test_hub_config.py
@@ -149,7 +149,7 @@ def test_hub_missing_tasks_config(hubverse_hub):
         print(hc)
 
 
-def test_get_task_id_values_all_rounds(hubverse_hub):
+def test_get_task_id_values(hubverse_hub):
     hub_path = AnyPath(hubverse_hub)
     hc = HubConfig(hub_path)
 
@@ -161,24 +161,6 @@ def test_get_task_id_values_all_rounds(hubverse_hub):
         "target_end_date": {"2024-07-20", "2024-07-27", "1999-12-31", "2024-08-20"},
         "age": {10, 20, 30, 40, 50},
     }
-
-
-def test_get_task_id_values_single_round(hubverse_hub):
-    hub_path = AnyPath(hubverse_hub)
-    hc = HubConfig(hub_path)
-
-    assert hc.get_task_id_values("Round 2") == {
-        "target": {"starfleet entrance exam score"},
-        "age": {10, 20, 30, 40, 50},
-    }
-
-
-def test_get_task_id_values_missing_round(hubverse_hub):
-    hub_path = AnyPath(hubverse_hub)
-    hc = HubConfig(hub_path)
-
-    with pytest.raises(ValueError):
-        hc.get_task_id_values("missing round")
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_hub_config.py
+++ b/test/unit/test_hub_config.py
@@ -178,10 +178,7 @@ def test_get_task_id_values_missing_round(hubverse_hub):
     hc = HubConfig(hub_path)
 
     with pytest.raises(ValueError):
-        hc.get_task_id_values("missing round") == {
-            "target": {"starfleet entrance exam score"},
-            "age": {10, 20, 30, 40, 50},
-        }
+        hc.get_task_id_values("missing round")
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_hub_config.py
+++ b/test/unit/test_hub_config.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 
 import pytest
 from cloudpathlib import AnyPath
@@ -128,3 +129,20 @@ def test_hub_missing_tasks_config(hubverse_hub):
     with pytest.raises(FileNotFoundError):
         hc = HubConfig(hub_path, tasks_file="missing-tasks.json")
         print(hc)
+
+
+@pytest.mark.parametrize(
+    "value, expected_type",
+    [
+        ("a string", str),
+        (123, int),
+        (123.45, float),
+        ("2024-07-13", date),
+        (False, bool),
+    ],
+)
+def test_get_data_type(hubverse_hub, value, expected_type):
+    hub_path = AnyPath(hubverse_hub)
+    hc = HubConfig(hub_path)
+
+    assert hc._get_data_type(value) == expected_type


### PR DESCRIPTION
Next piece of the work for #14 

Here we're adding a new function that inspects a hub's `tasks.json` and returns a dictionary of `task_id`s and their possible values. This is information we'll need to determine the schema of the model_output file.

Next step:
Do the same thing, except for `output_type_id`s, which are configured a bit differently

Here's what it looks like in action:

```python
In [1]: from cloudpathlib import AnyPath

In [2]: from hubverse_transform.hub_config import HubConfig

In [3]: hub_path = AnyPath('s3://bsweger-flusight-forecast')

In [4]: hc = HubConfig(hub_path)

In [5]: task_id_values = hc.get_task_id_values()

In [6]: task_id_values.keys()
Out[6]: dict_keys(['reference_date', 'target', 'horizon', 'location', 'target_end_date'])

In [7]: task_id_values['horizon']
Out[7]: {-1, 0, 1, 2, 3}

In [8]: task_id_values['target']
Out[8]: {'wk flu hosp rate change', 'wk inc flu hosp'}
```