### PR TITLE
Fix a bug when opening a parquet file on S3

### DIFF
--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -208,12 +208,12 @@ class ModelOutputHandler:
             model_output_table = csv.read_csv(model_output_file, convert_options=options)
         else:
             # temp fix: force location and output_type_id columns to string
-            schema_new = pq.read_schema(self.input_file)
+            model_output_file = self.fs_input.open_input_file(self.input_file)
+            schema_new = pq.read_schema(model_output_file)
             for field_name in ["location", "output_type_id"]:
                 field_idx = schema_new.get_field_index(field_name)
                 if field_idx >= 0:
                     schema_new = schema_new.set(field_idx, pa.field(field_name, pa.string()))
-            model_output_file = self.fs_input.open_input_file(self.input_file)
             model_output_table = pq.read_table(model_output_file, schema=schema_new)
 
         return model_output_table


### PR DESCRIPTION
When reading parquet files from S3, hubverse-transform does an initial read to get the schema (so we can override it if necessary). However, the read fails because it's reading the wrong thing, and the transform process tries to open the model-output data on the local filesystem instead of on S3.

I opened an issue to address the lack of S3 test cases, which resulted in this bug hitting production:
https://github.com/hubverse-org/hubverse-transform/issues/30

-----------------

**Reproducing the bug (main branch)**
```
from hubverse_transform.model_output import ModelOutputHandler

bucket = "covid-variant-nowcast-hub"
key = "raw/model-output/CADPH-CATaLog/2024-10-30-CADPH-CATaLog.parquet"
mo = ModelOutputHandler.from_s3(bucket, key)

mo.read_file()
FileNotFoundError: [Errno 2] Failed to open local file 'covid-variant-nowcast-hub/raw/model-output/CADPH-CATaLog/2024-10-30-CADPH-CATaLog.parquet'. Detail: [errno 2] No such file or directory
```

**Hotfix branch**

```
from hubverse_transform.model_output import ModelOutputHandler

bucket = "covid-variant-nowcast-hub"
key = "raw/model-output/CADPH-CATaLog/2024-10-30-CADPH-CATaLog.parquet"
mo = ModelOutputHandler.from_s3(bucket, key)

mo.read_file()
11/14/2024 03:41:44 PM -  INFO - hubverse_transform.model_output - Reading file: covid-variant-nowcast-hub/raw/model-output/CADPH-CATaLog/2024-10-30-CADPH-CATaLog.parquet
Out[2]:
pyarrow.Table
nowcast_date: date32[day]
target_date: date32[day]
location: string
clade: string
output_type: string
output_type_id: string
value: double
----
nowcast_date: [[2024-10-30,2024-10-30,2024-10-30,2024-10-30,2024-10-30,...,2024-10-30,2024-10-30,2024-10-30,2024-10-30,2024-10-30]]
target_date: [[2024-09-29,2024-09-29,2024-09-29,2024-09-29,2024-09-29,...,2024-11-09,2024-11-09,2024-11-09,2024-11-09,2024-11-09]]
location: [["CA","CA","CA","CA","CA",...,"CA","CA","CA","CA","CA"]]
clade: [["24A","24B","24C","24E","24F",...,"24E","24F","24G","other","recombinant"]]
output_type: [["mean","mean","mean","mean","mean",...,"mean","mean","mean","mean","mean"]]
output_type_id: [[null,null,null,null,null,...,null,null,null,null,null]]
value: [[0.14849599094829108,0.1222214479203117,0.06787864781410405,0.4525252654061046,0.08532844142325537,...,0.471118035776486,0.26748908545066635,0.04903886248628789,0,0.03683909600061764]]
```

