### PR TITLE
[chore] add permissions to the code checks workflow

### DIFF
--- a/.github/workflows/run-code-checks.yaml
+++ b/.github/workflows/run-code-checks.yaml
@@ -1,4 +1,6 @@
 name: run-code-checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Fixes a security alert raised by GitHub's CodeQL: https://github.com/hubverse-org/hubverse-transform/security/code-scanning/1

This changeset adds explicit permissions to the test/lint workflow for the repo.