### PR TITLE
Update remaining Python dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.11
+  rev: v0.11.1
   hooks:
     # Run the linter.
     - id: ruff
@@ -9,7 +9,7 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: check-yaml
@@ -18,6 +18,6 @@ repos:
     args: [--allow-missing-credentials]
   - id: detect-private-key
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.4
+  rev: v2.4.1
   hooks:
   - id: codespell

--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -8,6 +8,7 @@ This handler, along with the actual transformation module (hubverse_transform), 
 - To avoid tightly coupling AWS infrastructure to the more general hubverse_transform module that can be used for hubs hosted elsewhere
 - To allow faster iteration and testing of the hubverse_transform module without needing to update the IaC repo or redeploy AWS resources
 """
+
 import json
 import logging
 import urllib.parse
@@ -36,20 +37,24 @@ def lambda_handler(event, context):
             logger.info(f"Deleting file: {bucket}/{key}")
             mo.delete_model_output()
         else:
-            logger.info({
-                "msg": "Event type not supported, skipping",
-                "event_source": event_source,
-                "event": event_name,
-                "file": f"{bucket}/{key}"
-            })
+            logger.info(
+                {
+                    "msg": "Event type not supported, skipping",
+                    "event_source": event_source,
+                    "event": event_name,
+                    "file": f"{bucket}/{key}",
+                }
+            )
             return
     except UserWarning:
         pass
     except Exception as e:
-        logger.exception({
-            "msg": "Error handling file",
-            "event": event_name,
-            "event_source": event_source,
-            "file": f"{bucket}/{key}",
-            "error": str(e)
-        })
+        logger.exception(
+            {
+                "msg": "Error handling file",
+                "event": event_name,
+                "event_source": event_source,
+                "file": f"{bucket}/{key}",
+                "error": str(e),
+            }
+        )

--- a/faas/lambda_retrigger_model_output_add.py
+++ b/faas/lambda_retrigger_model_output_add.py
@@ -2,6 +2,7 @@
 Update metadata for all files in the raw/model-output/ directory of a specified AWS S3 bucket.
 This script can be used for force re-triggering the lambda that transforms hubverse model-output files.
 """
+
 import argparse
 from datetime import datetime, timezone
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,9 +8,9 @@ botocore==1.37.17
     # via
     #   boto3
     #   s3transfer
-cloudpathlib==0.18.1
+cloudpathlib==0.21.0
     # via hubverse-transform (pyproject.toml)
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 jmespath==1.0.1
     # via
@@ -20,13 +20,11 @@ mypy==1.15.0
     # via hubverse-transform (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
-numpy==1.26.4
-    # via pyarrow
 packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
-pyarrow==16.1.0
+pyarrow==19.0.1
     # via hubverse-transform (pyproject.toml)
 pytest==8.3.5
     # via
@@ -36,13 +34,13 @@ pytest-mock==3.14.0
     # via hubverse-transform (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
-ruff==0.4.4
+ruff==0.11.1
     # via hubverse-transform (pyproject.toml)
 s3transfer==0.11.4
     # via boto3
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via mypy
-urllib3==2.2.1
+urllib3==2.3.0
     # via botocore

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,21 +8,19 @@ botocore==1.37.17
     # via
     #   boto3
     #   s3transfer
-cloudpathlib==0.18.1
+cloudpathlib==0.21.0
     # via hubverse-transform (pyproject.toml)
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-numpy==1.26.4
-    # via pyarrow
-pyarrow==16.1.0
+pyarrow==19.0.1
     # via hubverse-transform (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
 s3transfer==0.11.4
     # via boto3
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-urllib3==2.2.1
+urllib3==2.3.0
     # via botocore

--- a/test/integration/test_model_output_integration.py
+++ b/test/integration/test_model_output_integration.py
@@ -4,8 +4,9 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 import pytest
-from hubverse_transform.model_output import ModelOutputHandler
 from pyarrow import parquet
+
+from hubverse_transform.model_output import ModelOutputHandler
 
 
 @pytest.fixture()

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pyarrow as pa
 import pytest
 from cloudpathlib import AnyPath
+
 from hubverse_transform.model_output import ModelOutputHandler
 
 # the mocker fixture used throughout is provided by pytest-mock


### PR DESCRIPTION
Dependabot opened a PR (#38) to bump numpy from 1.26.4 to 2.2.4.

Rather than do that (upgrading to numpy 2.0 is not trivial), this upgrades all Python dependencies (Dependabot only opens 5 PRs at once). As it turns out, the latest version of Pyarrow doesn't require numpy, so this is a better alternative and will also lessen the initial Dependabot noise.