### PR TITLE
refactor to use the hubdata package for hub access

### DIFF
--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -23,9 +23,11 @@ def lambda_handler(event, context):
     logger.info("Received event: " + json.dumps(event, indent=2))
 
     # info from the S3 event
-    event_source = event["Records"][0]["eventSource"]
-    event_name = event["Records"][0]["eventName"]
-    bucket = event["Records"][0]["s3"]["bucket"]["name"]
+    event_source = event["Records"][0]["eventSource"]  # ex: "aws:s3"
+    event_name = event["Records"][0]["eventName"]  # ex: "ObjectCreated:Put"
+    bucket = event["Records"][0]["s3"]["bucket"]["name"]  # ex: "covid-variant-nowcast-hub"
+
+    # ex: "raw/model-output/Hub-ensemble/2025-07-30-Hub-ensemble.parquet" :
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"], encoding="utf-8")
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Utilities for Hubverse model-output transformations"
 license = {text = "MIT"}
 readme = "README.md"
 requires-python = '>=3.10'
-version = "0.1.0"
+version = "1.0.0"
 classifiers = [
     'Programming Language :: Python :: 3',
     'License :: OSI Approved :: MIT License',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "hubverse-transform"
 description = "Utilities for Hubverse model-output transformations"
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = '>=3.10'
 version = "0.1.0"
 classifiers = [
     'Programming Language :: Python :: 3',
@@ -14,6 +14,7 @@ dependencies = [
     "boto3",
     "pyarrow>=16.0.0",
     "cloudpathlib[s3]",
+    "hubdata>=0.1.3",
 ]
 authors = [
     {name = "Becky Sweger", email = "rsweger@umass.edu"},

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,7 +8,11 @@ botocore==1.38.3
     # via
     #   boto3
     #   s3transfer
+click==8.2.1
+    # via hubdata
 cloudpathlib==0.21.0
+    # via hubverse-transform (pyproject.toml)
+hubdata==0.1.3
     # via hubverse-transform (pyproject.toml)
 iniconfig==2.1.0
     # via pytest
@@ -16,6 +20,10 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 mypy==1.15.0
     # via hubverse-transform (pyproject.toml)
 mypy-extensions==1.1.0
@@ -25,7 +33,11 @@ packaging==25.0
 pluggy==1.5.0
     # via pytest
 pyarrow==19.0.1
-    # via hubverse-transform (pyproject.toml)
+    # via
+    #   hubverse-transform (pyproject.toml)
+    #   hubdata
+pygments==2.19.2
+    # via rich
 pytest==8.3.5
     # via
     #   hubverse-transform (pyproject.toml)
@@ -34,12 +46,16 @@ pytest-mock==3.14.0
     # via hubverse-transform (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
+rich==14.1.0
+    # via hubdata
 ruff==0.11.7
     # via hubverse-transform (pyproject.toml)
 s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil
+structlog==25.4.0
+    # via hubdata
 typing-extensions==4.13.2
     # via mypy
 urllib3==2.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,19 +8,35 @@ botocore==1.38.3
     # via
     #   boto3
     #   s3transfer
+click==8.2.1
+    # via hubdata
 cloudpathlib==0.21.0
+    # via hubverse-transform (pyproject.toml)
+hubdata==0.1.3
     # via hubverse-transform (pyproject.toml)
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 pyarrow==19.0.1
-    # via hubverse-transform (pyproject.toml)
+    # via
+    #   hubverse-transform (pyproject.toml)
+    #   hubdata
+pygments==2.19.2
+    # via rich
 python-dateutil==2.9.0.post0
     # via botocore
+rich==14.1.0
+    # via hubdata
 s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil
+structlog==25.4.0
+    # via hubdata
 urllib3==2.4.0
     # via botocore

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -7,6 +8,7 @@ from urllib.parse import quote
 import pyarrow as pa  # type: ignore
 import pyarrow.parquet as pq  # type: ignore
 from cloudpathlib import AnyPath, S3Path
+from hubdata import create_hub_schema
 from pyarrow import csv, fs
 
 # Log to stdout
@@ -92,14 +94,14 @@ class ModelOutputHandler:
         """
 
         input_path = hub_path / mo_path  # type: ignore
-        sanitized_input_uri = self.sanitize_uri(input_path)
-        input_filesystem: tuple[fs.FileSystem, str] = fs.FileSystem.from_uri(sanitized_input_uri)
+        input_filesystem: tuple[fs.FileSystem, str] = fs.FileSystem.from_uri(self.sanitize_uri(input_path))
         self.fs_input: fs.FileSystem = input_filesystem[0]
         self.input_file: str = input_filesystem[1]
 
         output_filesystem: tuple[fs.FileSystem, str] = fs.FileSystem.from_uri(self.sanitize_uri(output_path))
         self.fs_output: fs.FileSystem = output_filesystem[0]
         self.output_path: str = output_filesystem[1]
+        self.tasks = self._read_tasks(hub_path)  # required by read_file() to get schema
 
         # get file name and type from input file (use the sanitized version)
         file_path = AnyPath(self.input_file)
@@ -141,9 +143,10 @@ class ModelOutputHandler:
         Parameters
         ----------
         bucket_name : str
-            The hub's S3 bucket.
+            The hub's S3 bucket. E.g., "covid-variant-nowcast-hub"
         s3_key : str
             The S3 object key of the incoming model-output file.
+            E.g., "raw/model-output/Hub-ensemble/2025-07-30-Hub-ensemble.parquet"
         origin_prefix : str
             The S3 prefix used to store a hub's original,
             pre-transformed data. Must be the first part of the s3_key.
@@ -182,6 +185,27 @@ class ModelOutputHandler:
         s3_output_path = S3Path(f"s3://{bucket_name}/{destination_path}")
 
         return cls(s3_bucket_path, s3_mo_path, s3_output_path)  # type: ignore
+
+
+    def _read_tasks(self, hub_path):
+        """
+        __init()__ helper that tries to load tasks.json from hub_path so that we can determine the read schema for it
+        """
+        tasks = None
+        hub_path = self.sanitize_uri(hub_path)
+        try:
+            filesystem, filesystem_path = fs.FileSystem.from_uri(hub_path)
+            tasks_json_path = filesystem_path + '/hub-config/tasks.json'
+            if filesystem.get_file_info(tasks_json_path).type == fs.FileType.NotFound:
+                logger.warning(f'could not find tasks.json: tasks_json_path={tasks_json_path!r}, '
+                               f'filesystem={filesystem}')
+            else:
+                with filesystem.open_input_file(tasks_json_path) as tasks_fp:
+                    tasks = json.load(tasks_fp)
+        except Exception as exc:
+            logger.warning(f'exception trying to read tasks.json: {exc!r}')
+        return tasks
+
 
     def raise_user_warning(self, path: str, msg: str) -> None:
         """Raise a warning if the class was instantiated with an invalid file."""
@@ -236,30 +260,42 @@ class ModelOutputHandler:
 
     def read_file(self) -> pa.table:
         """Read model-output file into PyArrow table."""
-
         logger.info(f"Reading file: {self.input_file}")
-
         if self.file_type == ".csv":
             model_output_file = self.fs_input.open_input_stream(self.input_file)
+            schema = self._get_schema(self.tasks, self.file_type, model_output_file)
             # normalize incoming missing data values to null, regardless of data type
             options = csv.ConvertOptions(
                 null_values=["na", "NA", "", " ", "null", "Null", "NaN", "nan"],
                 strings_can_be_null=True,
-                # temp fix: force location and output_type_id columns to string
-                column_types={"location": pa.string(), "output_type_id": pa.string()},
-            )
+                column_types=schema)
             model_output_table = csv.read_csv(model_output_file, convert_options=options)
         else:
-            # temp fix: force location and output_type_id columns to string
             model_output_file = self.fs_input.open_input_file(self.input_file)
-            schema_new = pq.read_schema(model_output_file)
-            for field_name in ["location", "output_type_id"]:
-                field_idx = schema_new.get_field_index(field_name)
-                if field_idx >= 0:
-                    schema_new = schema_new.set(field_idx, pa.field(field_name, pa.string()))
-            model_output_table = pq.read_table(model_output_file, schema=schema_new)
+            schema = self._get_schema(self.tasks, self.file_type, model_output_file)
+            model_output_table = pq.read_table(model_output_file, schema=schema)
 
         return model_output_table
+
+
+    @classmethod
+    def _get_schema(cls, tasks, file_type, model_output_file):
+        """
+        read_file() helper that returns a pa.schema. uses my tasks if they were able to be loaded. o/w we hard-code a
+        few common hub columns and take our chances!
+        """
+        if tasks:
+            schema = create_hub_schema(tasks)
+        elif file_type == ".csv":
+            schema = pa.schema({"location": pa.string(), "output_type_id": pa.string()})
+        else:
+            schema = pq.read_schema(model_output_file)
+            for field_name in ["location", "output_type_id"]:  # force location and output_type_id columns to string
+                field_idx = schema.get_field_index(field_name)
+                if field_idx >= 0:
+                    schema = schema.set(field_idx, pa.field(field_name, pa.string()))
+        return schema
+
 
     def add_columns(self, model_output_table: pa.table) -> pa.table:
         """Add model-output metadata columns to PyArrow table."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,3 +110,92 @@ def test_parquet_file(tmpdir, test_csv_file) -> str:
         pq.write_table(model_output_table, test_parquet_file)
 
     return str(test_file_path)
+
+
+#
+# schema-related fixtures that patch schema-related functions to override a pa.schema
+#
+
+@pytest.fixture()
+def schema_empty(mocker):
+    schema = pa.schema([])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)
+
+
+@pytest.fixture()
+def schema_reference_date(mocker):
+    schema = pa.schema([('reference_date', pa.date32()),
+                        ('target', pa.string()),
+                        ('horizon', pa.int64()),
+                        ('target_end_date', pa.date32()),
+                        ('location', pa.string()),
+                        ('output_type', pa.string()),
+                        ('output_type_id', pa.string()),
+                        ('value', pa.float64()),
+                        ('round_id', pa.string()),
+                        ('model_id', pa.string())])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)
+
+
+@pytest.fixture()
+def schema_origin_date(mocker):
+    schema = pa.schema([('origin_date', pa.date32()),
+                        ('target', pa.string()),
+                        ('horizon', pa.int64()),
+                        ('location', pa.string()),
+                        ('output_type', pa.string()),
+                        ('output_type_id', pa.string()),
+                        ('value', pa.float64()),
+                        ('round_id', pa.date32()),
+                        ('model_id', pa.string())])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)
+
+
+@pytest.fixture()
+def schema_origin_date_str_val(mocker):
+    schema = pa.schema([('origin_date', pa.date32()),
+                        ('target', pa.string()),
+                        ('horizon', pa.int64()),
+                        ('location', pa.string()),
+                        ('output_type', pa.string()),
+                        ('output_type_id', pa.string()),
+                        ('value', pa.string()),  # only diff b/w this and schema_origin_date()
+                        ('round_id', pa.date32()),
+                        ('model_id', pa.string())])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)
+
+
+@pytest.fixture()
+def schema_origin_date_no_model_round_ids(mocker):
+    schema = pa.schema([('origin_date', pa.date32()),
+                        ('target', pa.string()),
+                        ('horizon', pa.int64()),
+                        ('location', pa.string()),
+                        ('output_type', pa.string()),
+                        ('output_type_id', pa.string()),
+                        ('value', pa.float64()),
+                        # ('round_id', pa.date32()),  # diff b/w this and schema_origin_date()
+                        # ('model_id', pa.string()),  # ""
+                        ])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)
+
+
+@pytest.fixture()
+def schema_origin_date_no_model_round_ids_loc(mocker):
+    schema = pa.schema([('origin_date', pa.date32()),
+                        ('target', pa.string()),
+                        ('horizon', pa.int64()),
+                        # ('location', pa.string()),  # diff b/w this and schema_origin_date()
+                        ('output_type', pa.string()),
+                        ('output_type_id', pa.string()),
+                        ('value', pa.float64()),
+                        # ('round_id', pa.date32()),  # ""
+                        # ('model_id', pa.string()),  # ""
+                        ])
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._read_tasks", return_value={'a': 'dict'})
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler._get_schema", return_value=schema)

--- a/test/integration/data/flu-metrocast/hub-config/admin.json
+++ b/test/integration/data/flu-metrocast/hub-config/admin.json
@@ -1,0 +1,24 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/admin-schema.json",
+    "name": "Flu MetroCast",
+    "maintainer": "epiENGAGE",
+    "contact": {
+        "name": "Dongah Kim",
+        "email": "donga0223@gmail.com"
+    },
+    "repository": {
+        "host": "github",
+        "owner": "reichlab",
+        "name": "flu-metrocast"
+    },
+    "file_format": ["csv"],
+    "timezone": "US/Eastern",
+    "cloud": {
+        "enabled": true,
+        "host": {
+          "name": "aws",
+          "storage_service": "s3",
+          "storage_location": "reichlab-flu-metrocast-hub"
+        }
+    }
+}

--- a/test/integration/data/flu-metrocast/hub-config/admin.json
+++ b/test/integration/data/flu-metrocast/hub-config/admin.json
@@ -3,8 +3,8 @@
     "name": "Flu MetroCast",
     "maintainer": "epiENGAGE",
     "contact": {
-        "name": "Dongah Kim",
-        "email": "donga0223@gmail.com"
+        "name": "Joe Bloggs",
+        "email": "joe.blogs@cdc.gov"
     },
     "repository": {
         "host": "github",

--- a/test/integration/data/flu-metrocast/hub-config/model-metadata-schema.json
+++ b/test/integration/data/flu-metrocast/hub-config/model-metadata-schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Schema for Flu MetroCast Hub model metadata",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "type": "object",
+    "properties": {
+        "team_name": {
+            "description": "The name of the team submitting the model",
+            "type": "string"
+        },
+        "team_abbr": {
+            "description": "Abbreviated name of the team submitting the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_name": {
+            "description": "The name of the model",
+            "type": "string"
+        },
+        "model_abbr": {
+            "description": "Abbreviated name of the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_version": {
+            "description": "Identifier of the version of the model",
+            "type": "string"
+        },
+        "model_contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "repo_url": {
+            "description": "Repository containing code for the model",
+            "type": "string",
+            "format": "uri"
+        },
+        "license": {
+            "description": "License for use of model output data",
+            "type": "string",
+            "enum": [
+                "CC0-1.0",
+                "CC-BY-4.0",
+                "CC-BY_SA-4.0",
+                "PPDL",
+                "ODC-by",
+                "ODbL",
+                "OGL-3.0"
+            ]
+        },
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization.",
+            "type": "boolean"
+        },
+        "citation": {
+            "description": "One or more citations for this model",
+            "type": "string",
+            "examples": [
+                "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            ]
+        },
+        "team_funding": {
+            "description": "Any information about funding source for the team or members of the team.",
+            "type": "string",
+            "examples": [
+                "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            ]
+        },
+        "methods": {
+            "description": "A summary of the methods used by this model (5000 character limit).",
+            "type": "string",
+            "maxLength": 5000
+        },
+        "methods_url": {
+            "description": "A link to a complete write-up of the model specification, with mathematical details. This could be a peer-reviewed article, preprint, or an unpublished PDF or webpage stored at a public url somewhere.",
+            "type": "string",
+            "format": "uri"
+        },
+        "data_sources": {
+            "description": "List or description of data inputs used by the model. For example: public data from NYC DOHMH, CDC NSSP surveillance data, etc...",
+            "type": "string"
+        },
+        "ensemble_of_hub_models": {
+            "description": "Indicator for whether this model is an ensemble of other Hub models",
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "team_name",
+        "team_abbr",
+        "model_name",
+        "model_abbr",
+        "model_contributors",
+        "license",
+        "designated_model",
+        "methods",
+        "data_sources"
+    ]
+}

--- a/test/integration/data/flu-metrocast/hub-config/tasks.json
+++ b/test/integration/data/flu-metrocast/hub-config/tasks.json
@@ -1,0 +1,164 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "reference_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2025-01-25", "2025-02-01", "2025-02-08",
+                                "2025-02-15", "2025-02-22", "2025-03-01", "2025-03-08",
+                                "2025-03-15", "2025-03-22", "2025-03-29", "2025-04-05",
+                                "2025-04-12", "2025-04-19", "2025-04-26", "2025-05-03",
+                                "2025-05-10", "2025-05-17", "2025-05-24", "2025-05-31"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["ILI ED visits"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [0, 1, 2, 3, 4]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": [
+                              "NYC",
+                              "Bronx",
+                              "Brooklyn",
+                              "Manhattan",
+                              "Queens",
+                              "Staten Island"
+                              ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2025-01-25",
+                                "2025-02-01", "2025-02-08", "2025-02-15", "2025-02-22",
+                                "2025-03-01", "2025-03-08", "2025-03-15", "2025-03-22",
+                                "2025-03-29", "2025-04-05", "2025-04-12", "2025-04-19",
+                                "2025-04-26", "2025-05-03", "2025-05-10", "2025-05-17",
+                                "2025-05-24", "2025-05-31", "2025-06-07", "2025-06-14",
+                                "2025-06-21", "2025-06-28"
+
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "quantile": {
+                            "is_required": true,
+                            "output_type_id": {
+                                "required": [0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "ILI ED visits",
+                            "target_name": "ED visits due to ILI",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": "ILI ED visits"
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of ED visits due to ILI in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                },
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2025-01-25", "2025-02-01", "2025-02-08",
+                                "2025-02-15", "2025-02-22", "2025-03-01", "2025-03-08",
+                                "2025-03-15", "2025-03-22", "2025-03-29", "2025-04-05",
+                                "2025-04-12", "2025-04-19", "2025-04-26", "2025-05-03",
+                                "2025-05-10", "2025-05-17", "2025-05-24", "2025-05-31"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["Flu ED visits pct"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [-1, 0, 1, 2, 3, 4]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": [
+                              "Austin",
+                              "Houston",
+                              "Dallas",
+                              "El Paso",
+                              "San Antonio"
+                              ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2025-01-25",
+                                "2025-02-01", "2025-02-08", "2025-02-15", "2025-02-22",
+                                "2025-03-01", "2025-03-08", "2025-03-15", "2025-03-22",
+                                "2025-03-29", "2025-04-05", "2025-04-12", "2025-04-19",
+                                "2025-04-26", "2025-05-03", "2025-05-10", "2025-05-17",
+                                "2025-05-24", "2025-05-31", "2025-06-07", "2025-06-14",
+                                "2025-06-21", "2025-06-28"
+
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "quantile": {
+                            "is_required": true,
+                            "output_type_id": {
+                                "required": [0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0,
+                                "maximum" : 100
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "Flu ED visits pct",
+                            "target_name": "Percentage of ED visits due to influenza",
+                            "target_units": "percentage",
+                            "target_keys": {
+                                "target": "Flu ED visits pct"
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the percentage of ED visits due to flu in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {
+                "relative_to": "reference_date",
+                "start": -6,
+                "end": 333
+            }
+        }
+    ],
+    "output_type_id_datatype": "auto",
+    "derived_task_ids": [
+      "target_end_date"
+    ]
+}


### PR DESCRIPTION
This PR refactors hubverse-transform  to use the hubdata package. Mainly it changes `ModelOutputHandler.read_file()` to use the schema returned by the new `_get_schema()` method that calls hubdata's `create_hub_schema()` function. This fixes the hard-coded setting of the `location` and `output_type_id` column types to string.

Note that our approach to integrating the hubdata package ended up being to call `create_hub_schema()` rather than getting `connect_hub()` to work, due to unexpected complexities in coding the latter. (I.e., the code liked it better this way.) This requires loading tasks via `ModelOutputHandler._read_tasks()` (something `connect_hub()` would have done for us), but that's the tradeoff.

Additional notes:

- `ModelOutputHandler._get_schema()`: tries calling create_hub_schema() on hub tasks (if found). o/w it uses hard-coded fields for csv and parequet, as before
- **lambda_function.py**, `ModelOutputHandler.from_s3()`: added event example comments
- **test_model_output_integration.py**: add schema and tasks tests
- **data/flu-metrocast/hub-config/**: added a new test hub
- **pyproject.toml**: add "hubdata>=0.1.3". bumped requires-python to '>=3.10' (required by hubdata dependency)


# notes re: second commit

The second commit attempts to address all of the reviewer's comments. Reviewing it by itself probably makes the most sense. Summary:

- ModelOutputHandler.__init__(): error if tasks could not be loaded from tasks.json
- ModelOutputHandler._get_schema(): remove hard-coded fallback if no tasks. left as a separate function to ease mocking from tests
- test/integration/data/flu-metrocast/hub-config/admin.json: anonymized personal data
- test/conftest.py: added schema override fixtures for various test cases to control tests and avoid error if no tasks
- test/integration/test_model_output_integration.py: added appropriate schema override fixtures to all tests. remove unnecessary test__get_schema() test
- test/unit/test_model_output.py: "". split test_location_or_output_type_id_column_schema_parquet() into two cases because it needs two different schemas